### PR TITLE
chore: add Clean Architecture convention for server-side projects

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,6 +112,17 @@ Every change, no matter how small, must go through a branch and PR. Never commit
 - XML doc comments on public APIs
 - AAA pattern for tests (Arrange, Act, Assert)
 
+### Architecture (server-side projects only)
+- Use **Clean Architecture** for all server-side C# projects
+- Four layers, strictly enforced:
+  - `Domain` — entities, value objects, domain events; no dependencies
+  - `Application` — use cases, interfaces, DTOs; depends on Domain only
+  - `Infrastructure` — Dapper repositories, FluentMigrator migrations, external service adapters; depends on Application
+  - `Api` — ASP.NET Core controllers, gRPC endpoints, middleware; depends on Application
+- **Dependency rule**: outer layers depend on inner layers, never the reverse
+- Domain and Application layers must have **zero framework dependencies** (no ASP.NET, no Dapper references)
+- Infrastructure implements interfaces defined in Application (repository pattern)
+
 ### Task Tracking
 - Each task maps to a GitHub Issue
 - Milestones = Phases


### PR DESCRIPTION
## Summary
- Adds a mandatory Clean Architecture section to `CLAUDE.md` scoped to server-side C# projects
- Defines four layers: Domain, Application, Infrastructure, Api
- Enforces the dependency rule (outer depends on inner, never reversed)
- Specifies that Domain and Application must have zero framework dependencies
- Infrastructure implements interfaces defined in Application (repository pattern)

## Type of Change
- [x] Chore / project conventions

## Checklist
- [x] Commit message follows Conventional Commits spec
- [x] Branch named per convention (`kumarann/chore/...`)
- [x] Branch is up to date with `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)