### PR TITLE
chore: trim PR template and enforce its use in workflow

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,204 +1,26 @@
-# Pull Request
-
 ## Description
 
-<!-- Provide a clear and concise description of your changes -->
+<!-- What does this PR do and why? -->
 
-### What does this PR do?
+## Closes #
 
-<!-- Describe the main purpose of this pull request -->
+<!-- Link the issue this PR resolves, e.g. Closes #42 -->
 
-### Why is this change needed?
+## Type of change
 
-<!-- Explain the motivation or problem this PR addresses -->
+<!-- Mark the relevant type(s) with an [x] -->
 
----
-
-## Related Issues
-
-<!-- Link to related issues using keywords like "Closes", "Fixes", or "Resolves" -->
-<!-- Example: Closes #123, Fixes #456 -->
-
-- Related to #
-
----
-
-## Type of Change
-
-<!-- Mark the relevant option(s) with an [x] -->
-
-- [ ] 🐛 **Bug fix** (non-breaking change that fixes an issue)
-- [ ] ✨ **New feature** (non-breaking change that adds functionality)
-- [ ] 💥 **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
-- [ ] 📝 **Documentation** (changes to documentation only)
-- [ ] 🎨 **Style** (formatting, missing semicolons, etc.; no code change)
-- [ ] ♻️ **Refactor** (refactoring production code, e.g., renaming a variable)
-- [ ] ⚡ **Performance** (changes that improve performance)
-- [ ] ✅ **Test** (adding or updating tests)
-- [ ] 🔧 **Chore** (updating build tasks, package manager configs, etc.)
-- [ ] 🔁 **CI/CD** (changes to CI/CD pipelines)
-
----
-
-## Phase & Milestone
-
-<!-- Indicate which phase this PR belongs to -->
-
-- **Phase**: <!-- e.g., Phase 2, Phase 3 -->
-- **Milestone**: <!-- Link to GitHub milestone -->
-
----
-
-## Changes Made
-
-<!-- Provide a detailed list of changes -->
-
-### Added
--
-
-### Changed
--
-
-### Removed
--
-
-### Fixed
--
-
----
-
-## Testing
-
-### How Has This Been Tested?
-
-<!-- Describe the tests you ran to verify your changes -->
-
-- [ ] Unit tests
-- [ ] Integration tests
-- [ ] Manual testing
-- [ ] End-to-end tests
-
-### Test Configuration
-
-<!-- Provide details about your test environment -->
-
-- **OS**: <!-- e.g., Windows 11 with WSL 2 (Ubuntu 22.04) -->
-- **.NET Version**: <!-- e.g., .NET 8.0 -->
-- **Database**: <!-- e.g., PostgreSQL 15 -->
-- **Docker Version**: <!-- if applicable -->
-
-### Test Coverage
-
-<!-- If applicable, mention test coverage percentage or scope -->
-
-- Coverage: <!-- e.g., 85% -->
-
----
-
-## Screenshots / Recordings
-
-<!-- If applicable, add screenshots or screen recordings to help explain your changes -->
-<!-- You can drag and drop images directly into this text area -->
-
-### Before
-
-<!-- Screenshot or description of behavior before the change -->
-
-### After
-
-<!-- Screenshot or description of behavior after the change -->
-
----
+- [ ] `feat` — new feature
+- [ ] `fix` — bug fix
+- [ ] `docs` — documentation only
+- [ ] `chore` — maintenance / tooling / config
+- [ ] `ci` — CI/CD pipeline changes
+- [ ] `refactor` — code restructure, no behaviour change
+- [ ] `test` — adding or updating tests
 
 ## Checklist
 
-<!-- Mark completed items with an [x] -->
-
-### Code Quality
-
-- [ ] My code follows the style guidelines of this project (see [CONTRIBUTING.md](../CONTRIBUTING.md))
-- [ ] I have performed a self-review of my own code
-- [ ] I have commented my code, particularly in hard-to-understand areas
-- [ ] My changes generate no new warnings
-- [ ] I have removed any debugging code or console logs
-
-### Testing
-
-- [ ] I have added tests that prove my fix is effective or that my feature works
-- [ ] New and existing unit tests pass locally with my changes
-- [ ] Any dependent changes have been merged and published
-
-### Documentation
-
-- [ ] I have made corresponding changes to the documentation
-- [ ] I have updated the README.md (if applicable)
-- [ ] I have updated the ARCHITECTURE.md (if applicable)
-- [ ] I have added XML documentation comments to public APIs
-
-### Git & GitHub
-
-- [ ] My branch is up to date with the main branch
-- [ ] My commits follow the commit message guidelines (Conventional Commits)
-- [ ] I have squashed any "fix typo" or "oops" commits
-- [ ] I have linked this PR to the related issue(s)
-
-### Dependencies
-
-- [ ] I have checked that no new dependencies were added unnecessarily
-- [ ] Any new dependencies are properly documented
-- [ ] Dependencies are pinned to specific versions (if applicable)
-
----
-
-## Additional Context
-
-<!-- Add any other context about the pull request here -->
-
-### Breaking Changes
-
-<!-- If this is a breaking change, describe what breaks and how to migrate -->
-
-### Migration Guide
-
-<!-- If applicable, provide step-by-step migration instructions -->
-
-### Performance Impact
-
-<!-- Describe any performance implications of this change -->
-
-### Security Considerations
-
-<!-- Highlight any security-related aspects of this PR -->
-
----
-
-## Reviewer Notes
-
-<!-- Any specific areas you'd like reviewers to focus on? -->
-
-### Focus Areas
-
-<!-- What should reviewers pay special attention to? -->
-
-### Questions for Reviewers
-
-<!-- Any questions or uncertainties you'd like feedback on? -->
-
----
-
-## Deployment Notes
-
-<!-- Any special deployment considerations? -->
-
-- [ ] Requires database migration
-- [ ] Requires configuration changes
-- [ ] Requires infrastructure changes (Terraform, Kubernetes)
-- [ ] Requires data migration or seeding
-
-### Rollback Plan
-
-<!-- If something goes wrong, how do we roll back? -->
-
----
-
-**Thank you for contributing to Jamtrack Radio! 🎵**
+- [ ] Branch is up to date with `main`
+- [ ] Commit message follows Conventional Commits (`feat:`, `fix:`, `docs:`, etc.)
+- [ ] Issue is linked above (`Closes #`)
+- [ ] Self-reviewed — code does what it says, no debug artifacts left in

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,9 +80,9 @@ Every change, no matter how small, must go through a branch and PR. Never commit
    wsl bash -c "cd /mnt/c/training/jamtrack-radio && git push origin kumarann/<type>/<description>"
    ```
 
-5. **Create a PR** via WSL `gh`:
+5. **Create a PR** via WSL `gh` (use `--body-file` to load the template):
    ```bash
-   gh pr create --repo kumaran-naidoo-derivco/jamtrack-radio --base main --head kumarann/<type>/<description> --title "..." --body "..."
+   gh pr create --repo kumaran-naidoo-derivco/jamtrack-radio --base main --head kumarann/<type>/<description> --title "..." --body-file .github/pull_request_template.md
    ```
 
 6. **Wait for CI** to pass (`build` check must be green).
@@ -102,6 +102,7 @@ Every change, no matter how small, must go through a branch and PR. Never commit
 - Branch naming: `kumarann/<type>/<description>` — e.g. `kumarann/feature/playlist-service`, `kumarann/docs/update-readme`
 - Stage specific files by name — never `git add .` or `git add -A`
 - Squash merge preferred for feature/docs/chore branches
+- PR body must follow the template in `.github/pull_request_template.md`. Use `--body-file .github/pull_request_template.md` or match the template structure when passing `--body` inline.
 
 ### Code Style (C#)
 - Follow Microsoft C# conventions


### PR DESCRIPTION
## Description

<!-- What does this PR do and why? -->

## Closes #

<!-- Link the issue this PR resolves, e.g. Closes #42 -->

## Type of change

<!-- Mark the relevant type(s) with an [x] -->

- [ ] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `chore` — maintenance / tooling / config
- [ ] `ci` — CI/CD pipeline changes
- [ ] `refactor` — code restructure, no behaviour change
- [ ] `test` — adding or updating tests

## Checklist

- [ ] Branch is up to date with `main`
- [ ] Commit message follows Conventional Commits (`feat:`, `fix:`, `docs:`, etc.)
- [ ] Issue is linked above (`Closes #`)
- [ ] Self-reviewed — code does what it says, no debug artifacts left in
