### PR TITLE
docs: restructure project phases — VMs → ACA → AKS progression

### DIFF
--- a/.claude/workflow-state.json
+++ b/.claude/workflow-state.json
@@ -22,5 +22,5 @@
     "value-report": false
   },
   "lastUpdated": "2026-04-01",
-  "notes": "Product Discovery (Steps 1-7) complete for jamtrack-radio. Feature Discovery begins with identity-service."
+  "notes": "Product Discovery (Steps 1-7) complete for jamtrack-radio. Feature Discovery begins with identity-service. Phase structure restructured 2026-04-07: VMs (Phase 3) → ACA (Phase 6) → AKS (Phase 7). Old Phase 3 (Docker & Local K8s) removed."
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,15 +38,18 @@ You are **Kintsugi**, a software development coach. Your role is to upskill the 
 | Phase 0 | Environment Setup | ✅ Complete (19/19) |
 | Phase 1 | Repo Documentation & Templates | ✅ Complete (10/10) |
 | Phase 2 | Local Dev Environment (C# + Postgres) | 🔄 In Progress |
-| Phase 3 | Docker & Local K8s | ⏳ Not started |
-| Phase 4 | Azure Deployment | ⏳ Not started |
-| Phase 5 | AWS Deployment | ⏳ Not started |
-| Phase 6 | Monitoring & Observability | ⏳ Not started |
-| Phase 7 | Final Docs & Packaging | ⏳ Not started |
+| Phase 3 | Azure VM Hosting | ⏳ Not started |
+| Phase 4 | Feature Completion (Playlist, Storage, API Gateway) | ⏳ Not started |
+| Phase 5 | Containerisation (Docker + ACR) | ⏳ Not started |
+| Phase 6 | Azure Container Apps (ACA) | ⏳ Not started |
+| Phase 7 | Azure Kubernetes Service (AKS) | ⏳ Not started |
+| Phase 8 | AWS Deployment (EKS) | ⏳ Not started |
+| Phase 9 | Monitoring & Observability (ELK + ClickHouse) | ⏳ Not started |
+| Phase 10 | Final Docs & Packaging | ⏳ Not started |
 
 ## Up Next
 
-- **Phase 2, Task 2.4**: Product Discovery — Architecture (Steps 5a–5d), Architect Sign-off (Step 6), and Project Plan (Step 7)
+- **Phase 2, Task 2.5**: Identity Service — Feature Discovery, Design, Implementation, Tests
 
 ## Key Decisions
 

--- a/docs/architecture/jamtrack-radio/architect-signoff.md
+++ b/docs/architecture/jamtrack-radio/architect-signoff.md
@@ -47,7 +47,7 @@ No cross-service DB reads. Cross-service references use UUID values only (no rel
 | `token_hash` | Secret | SHA-256 hash — raw token never stored | `RefreshToken` entity; `RefreshTokenCommand` |
 | `email` | PII — Restricted | Hashed in logs; GDPR right to erasure | Serilog destructuring; soft-delete + hard-delete pipeline |
 | `storage_ref`, `artwork_ref` | Confidential | Authenticated blob access; no public URLs | `Streaming Service` validates ownership via gRPC before streaming |
-| RS256 private key | Secret | Key Vault (Phase 4+), K8s Secret (Phase 3) | `LoginCommand` — `IdentityGrpcService` |
+| RS256 private key | Secret | Key Vault + Managed Identity (Phase 3+), Workload Identity (Phase 7) | `LoginCommand` — `IdentityGrpcService` |
 
 All classified data has a corresponding control. No secret data is unprotected. ✅
 
@@ -58,9 +58,9 @@ All classified data has a corresponding control. No secret data is unprotected. 
 | Boundary | Authentication | Authorisation | Encryption |
 |----------|---------------|--------------|------------|
 | Internet → API Gateway | HTTPS TLS 1.3 | n/a (public entry) | TLS termination at App Gateway |
-| API Gateway → Services | JWT Bearer validation middleware | Route-level role check | gRPC TLS (Phase 3+) |
+| API Gateway → Services | JWT Bearer validation middleware | Route-level role check | gRPC TLS (Phase 3+ over VNet) |
 | API Gateway → Streaming | JWT Bearer validation | Track ownership validation | HTTPS |
-| Services → PostgreSQL | SSL connection | DB credentials from K8s Secret / Key Vault | Encrypted at rest (Azure-managed) |
+| Services → PostgreSQL | SSL connection | DB credentials from Key Vault (Phase 3+) | Encrypted at rest (Azure-managed) |
 | Services → Azure Key Vault | Managed Identity | RBAC: `Key Vault Secrets User` role | HTTPS |
 | Services → Azure Blob | Managed Identity | RBAC: `Storage Blob Data Contributor` | HTTPS |
 | Dapr sidecar ↔ Service | localhost (same pod) | — | mTLS between sidecars (Phase 5) |
@@ -71,10 +71,16 @@ Every boundary has authentication + encryption defined. ✅
 
 ## Total Cost of Ownership (TCO) — Aggregated
 
-### Development (Phase 2–3): £0/month
+### Development (Phase 2): £0/month
 All services run locally. No cloud infrastructure cost.
 
-### Staging (Phase 4+): ~£197–256/month
+### Azure VMs (Phase 3–5): ~£37–50/month
+Services deploy to Azure VMs with managed PostgreSQL and Key Vault. Use `terraform destroy` when not actively developing to minimise cost.
+
+### Azure Container Apps (Phase 6): ~£55–70/month
+Services move to ACA with scale-to-zero. VMs decommissioned.
+
+### AKS Staging (Phase 7+): ~£197–256/month
 
 | Source | Monthly |
 |--------|---------|
@@ -84,7 +90,7 @@ All services run locally. No cloud infrastructure cost.
 | **Staging total (base)** | **~£198/month** |
 | + 30% buffer | **~£258/month** |
 
-### Production — Baseline (Phase 4+): ~£1,143/month
+### Production — Baseline (Phase 7+): ~£1,143/month
 
 | Source | Monthly |
 |--------|---------|
@@ -99,14 +105,15 @@ All services run locally. No cloud infrastructure cost.
 
 | Scenario | Monthly | Annual |
 |----------|---------|--------|
-| Development (Phase 2–3) | £0 | £0 |
-| Staging (Phase 4+) | ~£198–258 | ~£2,376–3,096 |
-| Production baseline (Phase 4+) | ~£1,159 | ~£13,908 |
+| Development (Phase 2) | £0 | £0 |
+| Azure VMs (Phase 3–5) | ~£37–50 | ~£450–600 |
+| ACA (Phase 6) | ~£55–70 | ~£660–840 |
+| AKS Staging (Phase 7+) | ~£198–258 | ~£2,376–3,096 |
+| AKS Production baseline (Phase 7+) | ~£1,159 | ~£13,908 |
 | Production 2× load | ~£1,316 | ~£15,792 |
 | Production 10× load | ~£1,727 | ~£20,724 |
-| **Phase 4 Year 1 total** | | **~£16,284–17,004** |
 
-**Budget note**: The requirements budget of £50–100/month applies to **Phase 4 development** (staging + build activity), not live production. Running staging with auto-shutdown and burstable nodes keeps within £100/month (see cloud-arch §7 — auto-shutdown saves ~£100/month).
+**Budget note**: Phases 3–6 comfortably fit within the £50–100/month budget. AKS (Phase 7+) requires cost optimisation (spot nodes, auto-shutdown — see cloud-arch §7) to stay near the upper bound.
 
 ---
 
@@ -114,8 +121,9 @@ All services run locally. No cloud infrastructure cost.
 
 | Risk | Probability | Impact | Mitigation |
 |------|-------------|--------|------------|
-| Dapr adds complexity in Phase 2 before value is evident | High | Low | Implement gRPC direct calls first; introduce Dapr at Phase 3 |
-| Budget overrun in Phase 4 (prod vs staging sizing confusion) | Medium | Medium | Auto-shutdown staging; burstable SKUs; Azure Cost Management budget alert from day one |
+| Dapr adds complexity in Phase 2 before value is evident | High | Low | Implement gRPC direct calls first; introduce Dapr at Phase 3 (VM) |
+| Budget overrun in Phase 7 (prod vs staging sizing confusion) | Medium | Medium | Auto-shutdown staging; burstable SKUs; Azure Cost Management budget alert from day one |
+| ACA → AKS migration complexity | Medium | Medium | Ensure service mesh and networking behaviour is equivalent between ACA and AKS; test Dapr component portability before decommissioning ACA |
 | `storage_ref` set asynchronously — track upload appears incomplete to user | Medium | Medium | Return upload status as `pending` until `StorageObjectCreated` event received; poll endpoint or webhook |
 | Key rotation complexity — RS256 private key | Low | High | JWKS endpoint from day one; never hardcode key in application |
 | pg_trgm full-text search insufficient at 10,000+ tracks | Low | Low | Evaluate at Phase 6; Elasticsearch already in ELK stack as fallback |

--- a/docs/architecture/jamtrack-radio/cloud-arch.md
+++ b/docs/architecture/jamtrack-radio/cloud-arch.md
@@ -4,29 +4,31 @@
 **Author**: Kintsugi (Cloud Architect)
 **Status**: Accepted
 **Skill**: `/cloud-architect jamtrack-radio` — DISCOVERY Step 5b
-**Inputs**: `software-arch.md` (6 services defined), `jamtrack-radio-requirements.md` (budget: £50–100/month Azure from Phase 4)
+**Inputs**: `software-arch.md` (6 services defined), `jamtrack-radio-requirements.md` (budget: £50–100/month target; reconciled to £200–300/month staging)
 
 ---
 
 ## 1. Phase-Aware Infrastructure Overview
 
-| Component | Phase 2 (local) | Phase 3 (local K8s) | Phase 4+ (Azure) |
-|-----------|-----------------|---------------------|------------------|
-| Compute | Docker Compose | Rancher Desktop K8s | Azure Kubernetes Service (AKS) |
-| Container registry | Local Docker | Local Docker | Azure Container Registry (ACR) |
-| Database | Docker PostgreSQL 16 | Docker PostgreSQL 16 | Azure Database for PostgreSQL Flexible Server |
-| Secrets | `.env.local` (gitignored) | K8s Secrets | Azure Key Vault |
-| Ingress | `localhost` ports | Traefik (Rancher Desktop) | Azure Application Gateway + WAF v2 |
-| DNS | — | — | Azure DNS |
-| Monitoring | stdout logs | stdout logs | ELK on AKS + ClickHouse |
-| Blob storage | Local filesystem mock | Azure Blob (remote) or local MinIO | Azure Blob Storage (Hot tier) |
-| Service mesh / sidecar | Dapr (local) | Dapr (K8s mode) | Dapr (K8s mode on AKS) |
-| Pub/sub broker | Redis (Docker) | Redis (Docker/K8s) | Azure Service Bus (Standard) |
-| Secrets vault | `.env.local` | K8s Secrets | Azure Key Vault |
+| Component | Phase 2 (local) | Phase 3 (Azure VMs) | Phase 5 (Docker + ACR) | Phase 6 (ACA) | Phase 7+ (AKS) |
+|-----------|-----------------|---------------------|----------------------|---------------|----------------|
+| Compute | `dotnet run` | Azure Linux VMs (B1s/B2s) | Docker on VMs | Azure Container Apps | Azure Kubernetes Service |
+| Container registry | — | — | Azure Container Registry (Basic) | ACR | ACR |
+| Database | Docker PostgreSQL 16 | Azure Database for PostgreSQL Flexible Server | Same (Flex Server) | Same (Flex Server) | Same (Flex Server) |
+| Secrets | `.env.local` (gitignored) | Azure Key Vault + VM Managed Identity | Key Vault + Managed Identity | ACA Key Vault references | Workload Identity + Key Vault |
+| Ingress | `localhost` ports | Nginx reverse proxy on VM | Nginx on VM | ACA built-in HTTPS ingress | Application Gateway + WAF v2 |
+| DNS | — | — | — | ACA managed domain | Azure DNS |
+| Monitoring | stdout logs | stdout + journalctl | stdout logs | ACA Log Analytics | ELK on AKS + ClickHouse |
+| Blob storage | Local filesystem mock | Azure Blob Storage (Hot LRS) | Same | Same | Same |
+| Service mesh / sidecar | Dapr (local) | Dapr CLI on VM | Dapr CLI in container | ACA built-in Dapr | Dapr (K8s mode on AKS) |
+| Pub/sub broker | Redis (Docker) | Redis (Docker on VM) | Redis (Docker on VM) | Azure Service Bus (Standard) | Azure Service Bus |
+| Est. monthly cost | £0 | ~£37–50 | ~£50 | ~£55–70 | ~£60–100 (spot nodes) |
+
+> **Phase 4** (Feature Completion) uses the same Azure VM infrastructure as Phase 3 — it adds services, not infrastructure changes.
 
 ---
 
-## 2. Azure Network Topology Diagram (Phase 4+)
+## 2. Azure Network Topology Diagram (Phase 7+ / AKS)
 
 Hub-spoke VNet topology. Internet traffic enters via Application Gateway + WAF v2, routes through the AKS subnet, and connects to the data tier via private endpoints. Azure services outside the VNet authenticate via Managed Identity.
 
@@ -70,7 +72,36 @@ Each namespace has a `ResourceQuota` to cap CPU and memory, and a default-deny `
 
 ## 5. Cost Estimate Table
 
-### Dev / Staging (monthly, Phase 4+)
+### Phase 3 — Azure VMs (monthly)
+
+| Resource | SKU / Config | Monthly cost |
+|----------|-------------|-------------|
+| Linux VMs (2× Standard_B1s) | Burstable, Ubuntu 22.04 LTS | ~£12 |
+| PostgreSQL Flexible Server | Burstable B_Standard_B1ms | ~£12 |
+| Azure Key Vault — Standard | Key operations | ~£1 |
+| Public IP (Basic, static) | | ~£3 |
+| OS disks (2× Premium SSD P4 30GB) | | ~£8 |
+| Bandwidth egress (dev traffic) | | ~£1 |
+| **Phase 3 total** | | **~£37/month** |
+
+> Upgrade app VM to Standard_B2s (~£12/month) if B1s is too small for 3 services. Total ~£50/month.
+
+### Phase 6 — Azure Container Apps (monthly)
+
+| Resource | SKU / Config | Monthly cost |
+|----------|-------------|-------------|
+| Container Apps (×6) | Consumption plan, scale-to-zero | ~£5–15 |
+| Log Analytics Workspace | Pay-per-GB (2 GB/day) | ~£30 |
+| Azure Service Bus — Standard | Per operation | ~£8 |
+| PostgreSQL Flexible Server | Burstable B_Standard_B1ms | ~£12 |
+| Azure Container Registry — Basic | 10 GB included | ~£4.50 |
+| Azure Key Vault — Standard | | ~£1 |
+| Azure Blob Storage (audio) — Hot LRS | 100 GB | ~£2 |
+| **Phase 6 total** | | **~£55–70/month** |
+
+> ACA Consumption plan charges per vCPU-second and GiB-second. With scale-to-zero, idle services cost £0. Dev workloads are low cost.
+
+### Phase 7 — AKS Staging (monthly)
 
 | Resource | SKU / Config | Monthly cost |
 |----------|-------------|-------------|
@@ -85,7 +116,7 @@ Each namespace has a `ResourceQuota` to cap CPU and memory, and a default-deny `
 
 > **Note**: This is below the £326 in the skill template because staging node pools are burstable B-series (lower cost). Apply the 30% buffer from the financial lens: **~£256/month worst case**.
 
-### Production — Baseline (monthly, Phase 4+)
+### Production — Baseline (monthly, Phase 7+)
 
 | Resource | SKU / Config | Monthly cost |
 |----------|-------------|-------------|
@@ -109,28 +140,33 @@ Each namespace has a `ResourceQuota` to cap CPU and memory, and a default-deny `
 
 | Scenario | Monthly | Annual | Notes |
 |----------|---------|--------|-------|
-| Development (Phase 2–3) | £0 | £0 | Local only |
-| Staging (Phase 4+) | £197–256 | £2,364–3,072 | Always-on |
-| Production baseline (Phase 4+) | £1,142 | £13,704 | |
+| Development (Phase 2) | £0 | £0 | Local only |
+| Azure VMs (Phase 3–4) | ~£37–50 | ~£450–600 | `terraform destroy` when not developing |
+| Docker + ACR on VMs (Phase 5) | ~£50 | ~£600 | Adds ACR Basic to VM cost |
+| ACA (Phase 6) | ~£55–70 | ~£660–840 | Scale-to-zero; VMs decommissioned |
+| AKS staging (Phase 7+) | £197–256 | £2,364–3,072 | Always-on; apply auto-shutdown |
+| AKS production baseline (Phase 7+) | £1,142 | £13,704 | |
 | Production at 2× | £1,295 | £15,540 | |
 | Production at 10× | £1,700 | £20,400 | |
-| **Phase 4 Year 1 total** | | **~£16,068–17,000** | Staging + prod baseline |
 
-> **Budget check**: The personal budget constraint is £50–100/month (requirements §3). This architecture significantly exceeds it at full Phase 4 deployment. **Mitigation**: Phase 4 development runs on staging only (£197–256/month with auto-shutdown — see §7). Production-grade sizing applies only if the platform is used for live streaming.
+> **Budget check**: The personal budget is £50–100/month (requirements §3, reconciled to £200–300/month for AKS staging). Phases 3–6 comfortably fit within this constraint. AKS (Phase 7+) requires cost optimisation (spot nodes, auto-shutdown) to stay near the upper bound.
 
 ---
 
 ## 7. Cost Optimisation Recommendations
 
-| Recommendation | Saving | Effort | Priority |
-|----------------|--------|--------|----------|
-| Auto-shutdown staging 19:00–08:00 | ~£100/month (staging) | Low | High |
-| Use Azure Spot instances for staging node pool | ~£50–80/month | Medium | Medium |
-| 1-year reserved instances for production compute | ~£120/month | Low | Medium (Phase 4+) |
-| Burstable B-series for PostgreSQL staging | Already applied | — | Done |
-| Set Log Analytics retention to 30 days hot / archive cold | ~£100/month at prod scale | Low | High |
-| Use Azure Blob Cool tier for tracks not accessed in 30 days | ~£5/month | Low | Phase 5 |
-| Budget alert at 80% of expected spend | £0 | Low | High — do this on day one |
+| Recommendation | Phase | Saving | Effort | Priority |
+|----------------|-------|--------|--------|----------|
+| VM auto-shutdown at 19:00 (Azure Auto-shutdown) | 3–5 | ~£15/month | Low | High |
+| `terraform destroy` when not actively developing | 3–5 | 100% during inactive periods | Low | High |
+| Budget alert at £60/month | 3+ | £0 | Low | High — do this on day one |
+| ACA scale-to-zero for idle services | 6 | ~£10–20/month | Low | High |
+| AKS auto-shutdown staging 19:00–08:00 | 7+ | ~£100/month | Low | High |
+| Use Azure Spot instances for AKS user node pool | 7+ | ~£50–80/month | Medium | Medium |
+| Burstable B-series for PostgreSQL staging | 3+ | Already applied | — | Done |
+| Set Log Analytics retention to 30 days hot / archive cold | 7+ | ~£100/month at prod scale | Low | High |
+| 1-year reserved instances for production compute | 7+ | ~£120/month | Low | Medium |
+| Use Azure Blob Cool tier for tracks not accessed in 30 days | 4+ | ~£5/month | Low | Low |
 
 ---
 
@@ -161,7 +197,7 @@ All charts share a common pattern. `values.yaml` holds defaults; environment-spe
 
 ---
 
-## 9. Physical Deployment Diagram (Azure — Phase 4+)
+## 9. Physical Deployment Diagram (Azure — Phase 7+ / AKS)
 
 Full Azure resource group view using official Azure service names and Azure Architecture Center icon conventions.
 

--- a/docs/architecture/jamtrack-radio/security-arch.md
+++ b/docs/architecture/jamtrack-radio/security-arch.md
@@ -26,7 +26,7 @@ Shows every trust boundary, data classification zone, and authentication mechani
 | User-private | Confidential | Listening history, stream events, display name | Access control, user data isolation |
 | PII | Restricted | Email addresses, IP addresses, OAuth subjects | GDPR controls, hashed in logs, pseudonymised in analytics |
 | Credentials | Secret | Password hashes, refresh token hashes, TOTP seeds | BCrypt / SHA-256 / AES-256; never logged; Key Vault at Phase 4 |
-| Signing keys | Secret | RS256 private key | Key Vault (Phase 4+); K8s Secret (Phase 3); `.env.local` (Phase 2) |
+| Signing keys | Secret | RS256 private key | Key Vault + Managed Identity (Phase 3+); Workload Identity (Phase 7); `.env.local` (Phase 2) |
 
 ---
 
@@ -64,12 +64,12 @@ Shows every trust boundary, data classification zone, and authentication mechani
 | Secrets in environment | `.env.local` gitignored; never in `appsettings.json` | Phase 2 | £0 | Information disclosure |
 | Generic error responses | `ProblemDetails` middleware suppresses stack traces | Phase 2 | £0 | Information disclosure |
 | Scrub sensitive fields in logs | `Serilog.Destructuring` — exclude `email`, `password`, `token` | Phase 2 | £0 | Information disclosure |
-| K8s Secrets for credentials | Replace `.env.local` with K8s Secrets | Phase 3 | £0 | Information disclosure |
-| Network policies (default-deny) | K8s NetworkPolicy per namespace | Phase 3 | £0 | Spoofing, escalation |
-| Azure Key Vault | RS256 private key, DB connection strings | Phase 4 | ~£1/month | Information disclosure |
-| WAF (OWASP ruleset) | Azure Application Gateway WAF v2 | Phase 4 | ~£183/month | Tampering, DoS |
-| Managed Identity | All AKS → Azure service auth via Entra ID workload identity | Phase 4 | £0 | Information disclosure — no credential secrets in pods |
-| Audit logging to ELK | Serilog structured events → Log Analytics | Phase 4 | Log storage cost | Repudiation |
+| Azure Key Vault + Managed Identity | RS256 private key, DB connection strings; VM Managed Identity for access | Phase 3 | ~£1/month | Information disclosure |
+| Network Security Groups (NSGs) | Subnet-level firewall rules on VNet | Phase 3 | £0 | Spoofing, escalation |
+| WAF (OWASP ruleset) | Azure Application Gateway WAF v2 | Phase 7 | ~£183/month | Tampering, DoS |
+| Workload Identity | AKS pod → Azure service auth via Entra ID federated credentials | Phase 7 | £0 | Information disclosure — no credential secrets in pods |
+| Network policies (default-deny) | K8s NetworkPolicy per namespace | Phase 7 | £0 | Spoofing, escalation |
+| Audit logging to ELK | Serilog structured events → Log Analytics | Phase 6+ (ACA Log Analytics), Phase 9 (ELK) | Log storage cost | Repudiation |
 | Signed container images | Cosign + Azure Container Registry trust policy | Phase 5 | £0 | Tampering — supply chain |
 | mTLS between services | Dapr mTLS (built-in) | Phase 5 | Operational cost | Spoofing — internal network |
 
@@ -96,7 +96,7 @@ Shows every trust boundary, data classification zone, and authentication mechani
 **JWT design:**
 - Access token expiry: **15 minutes**
 - Refresh token expiry: **90 days** — stored as SHA-256 hash in `refresh_tokens` table
-- Signing: **RS256** — private key in Key Vault (Phase 4+), K8s Secret (Phase 3), `.env.local` (Phase 2)
+- Signing: **RS256** — private key in Key Vault + Managed Identity (Phase 3+), Workload Identity (Phase 7), `.env.local` (Phase 2)
 - Claims: `sub` (userId), `email`, `roles[]`, `iat`, `exp`, `jti`
 - TOTP: optional; enabled per user; seed encrypted with AES-256-GCM before storage; encryption key in Key Vault
 
@@ -111,11 +111,11 @@ Shows every trust boundary, data classification zone, and authentication mechani
 | A03 | Injection | ✅ Controlled | Dapper parameterised queries; `FluentValidation` on all inputs |
 | A04 | Insecure Design | ✅ In progress | This document — STRIDE threat model + controls matrix |
 | A05 | Security Misconfiguration | ⚠️ Monitor | No default credentials; no stack traces in prod; `X-Powered-By` removed |
-| A06 | Vulnerable Components | ⚠️ Monitor | Dependabot enabled; `dotnet-outdated` in CI (Phase 3) |
+| A06 | Vulnerable Components | ⚠️ Monitor | Dependabot enabled; `dotnet-outdated` in CI (Phase 2+) |
 | A07 | Identity & Auth Failures | ✅ Controlled | Rate limiting; RS256 JWT; short expiry; refresh token rotation; TOTP |
 | A08 | Software & Data Integrity | ⚠️ Phase 5 | Signed container images (Cosign + ACR); SBOM generation in CI |
-| A09 | Security Logging & Monitoring | ⚠️ Phase 4 | Structured Serilog events; ELK alerts on `login_failed` spikes |
-| A10 | SSRF | ✅ N/A (Phase 2) | No user-controllable URLs at Phase 2; evaluate at Phase 4 for webhook features |
+| A09 | Security Logging & Monitoring | ⚠️ Phase 6+ | Structured Serilog events; ACA Log Analytics (Phase 6); ELK alerts on `login_failed` spikes (Phase 9) |
+| A10 | SSRF | ✅ N/A (Phase 2) | No user-controllable URLs at Phase 2; evaluate at Phase 7 for webhook features |
 
 ---
 
@@ -127,8 +127,8 @@ Shows every trust boundary, data classification zone, and authentication mechani
 | Rate limiting | ~2h dev time | High (brute force on login) | High | High | Must do — Phase 2 |
 | User data isolation | ~1h per endpoint | Medium (curious users) | High | High | Must do — Phase 2 |
 | TOTP 2FA | ~1 day dev time | Medium (account takeover) | High | High | Must do — Phase 2 |
-| Azure Key Vault | ~£1/month | Medium (secret exposure) | Critical | High | Phase 4 — do on first Azure deploy |
-| WAF | ~£183/month | Medium (OWASP attacks) | High | High | Phase 4 |
+| Azure Key Vault | ~£1/month | Medium (secret exposure) | Critical | High | Phase 3 — do on first Azure deploy |
+| WAF | ~£183/month | Medium (OWASP attacks) | High | High | Phase 7 |
 | mTLS between services | Operational overhead | Low (internal VNet attack) | High | Medium | Phase 5 — defer |
 | HSM for JWT signing | £750+/month | Very low | Critical | Medium | Defer indefinitely — oversized for Jamtrack Radio scale |
-| Penetration test | £5,000–10,000 | — | — | — | Phase 4 go-live if real users |
+| Penetration test | £5,000–10,000 | — | — | — | Phase 7 go-live if real users |


### PR DESCRIPTION
## Description

Restructures the project from 8 phases to 11 phases, bringing Azure experience forward with VM hosting in Phase 3 and adding Azure Container Apps as an intermediate step before AKS.

**New progression**: Local Dev (Phase 2) → Azure VMs (Phase 3) → Feature Completion on VMs (Phase 4) → Docker + ACR (Phase 5) → ACA (Phase 6) → AKS (Phase 7) → AWS EKS (Phase 8) → Monitoring (Phase 9) → Final Docs (Phase 10)

**Removed**: Old Phase 3 (Docker & Local K8s via Rancher Desktop) — replaced by real Azure infrastructure from Phase 3 onward.

## Closes #86

## Files changed

- **cloud-arch.md**: Multi-phase infrastructure overview table with VM/ACA/AKS columns; VM cost table (~£37/month), ACA cost table (~£55–70/month); all "Phase 4+" headings updated to "Phase 7+"
- **architect-signoff.md**: TCO table updated (Phase 3 is ~£37/month, not £0); RS256 key storage corrected; ACA→AKS migration risk added
- **security-arch.md**: "K8s Secret (Phase 3)" → "Key Vault + Managed Identity (Phase 3+)" throughout; phase numbers corrected
- **CLAUDE.md**: 11-phase table with updated names
- **workflow-state.json**: Notes updated with restructuring context

## Type of change

- [x] `docs` — documentation only

## Checklist

- [x] Branch is up to date with `main`
- [x] Commit message follows Conventional Commits
- [x] Issue is linked above (`Closes #86`)
- [x] Self-reviewed